### PR TITLE
Adds partial output of configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,38 @@ const localConfig = builder.buildConfiguration({
   instance: 'your-instance',
   apiToken: 'your-api-token'
 });
+
+// Generate partial configuration (without wrapper)
+const partialConfig = builder.buildConfiguration({
+  mode: 'remote',
+  serverUrl: 'https://api.example.com/mcp/default',
+  serverName: 'my-server',
+  includeWrapper: false  // Returns just the server entry without mcpServers wrapper
+});
+// Returns: { "my-server": { "type": "http", "url": "..." } }
+// Instead of: { "mcpServers": { "my-server": { "type": "http", "url": "..." } } }
+```
+
+#### Partial Configuration (without wrapper)
+
+The `includeWrapper` option allows you to generate just the server configuration entry without the outer wrapper (`mcpServers`, `servers`, or `extensions` depending on the client). This is useful when you need to merge configurations into an existing setup:
+
+```typescript
+// Generate partial config for merging into existing configuration
+const partialConfig = JSON.parse(builder.buildConfiguration({
+  mode: 'remote',
+  serverUrl: 'https://api.example.com/mcp/default',
+  serverName: 'glean_custom',
+  includeWrapper: false
+}));
+
+// Now you can easily merge it into an existing config
+const existingConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+existingConfig.mcpServers = {
+  ...existingConfig.mcpServers,
+  ...partialConfig
+};
+fs.writeFileSync(configPath, JSON.stringify(existingConfig, null, 2));
 ```
 
 ### Validate Configurations

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -54,22 +54,30 @@ export const MCPClientConfigSchema = z.object({
   supportedPlatforms: z.array(PlatformSchema),
   configFormat: z.enum(['json', 'yaml']),
   configPath: PlatformPathsSchema,
-  oneClick: z.object({
-    protocol: z.string(),
-    urlTemplate: z.string(),
-    configFormat: z.enum(['base64-json', 'url-encoded-json'])
-  }).optional(),
+  oneClick: z
+    .object({
+      protocol: z.string(),
+      urlTemplate: z.string(),
+      configFormat: z.enum(['base64-json', 'url-encoded-json']),
+    })
+    .optional(),
   configStructure: ConfigStructureSchema,
   securityNotes: z.string().optional(),
 });
 
-export const GleanServerConfigSchema = z.object({
-  mode: ServerModeSchema,
-  serverUrl: z.string().url().optional(),
-  serverName: z.string().optional(),
-  instance: z.string().optional(),
-  apiToken: z.string().optional(),
+export const BuildOptionsSchema = z.object({
+  includeWrapper: z.boolean().optional(),
 });
+
+export const GleanServerConfigSchema = z
+  .object({
+    mode: ServerModeSchema,
+    serverUrl: z.string().url().optional(),
+    serverName: z.string().optional(),
+    instance: z.string().optional(),
+    apiToken: z.string().optional(),
+  })
+  .merge(BuildOptionsSchema);
 
 export function validateClientConfig(data: unknown) {
   return MCPClientConfigSchema.parse(data);

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ import {
   PlatformPathsSchema,
   MCPClientConfigSchema,
   GleanServerConfigSchema,
+  BuildOptionsSchema,
   HttpServerConfigSchema,
   StdioServerConfigSchema,
   StdioServerConfigAltSchema,
@@ -34,6 +35,7 @@ export type ConfigStructure = z.infer<typeof ConfigStructureSchema>;
 export type PlatformPaths = z.infer<typeof PlatformPathsSchema>;
 export type MCPClientConfig = z.infer<typeof MCPClientConfigSchema>;
 export type GleanServerConfig = z.infer<typeof GleanServerConfigSchema>;
+export type BuildOptions = z.infer<typeof BuildOptionsSchema>;
 export type HttpServerConfig = z.infer<typeof HttpServerConfigSchema>;
 export type StdioServerConfig = z.infer<typeof StdioServerConfigSchema>;
 export type StdioServerConfigAlt = z.infer<typeof StdioServerConfigAltSchema>;
@@ -61,6 +63,7 @@ export {
   HttpConfigStructureSchema,
   StdioConfigStructureSchema,
   GleanServerConfigSchema,
+  BuildOptionsSchema,
   HttpServerConfigSchema,
   StdioServerConfigSchema,
   StdioServerConfigAltSchema,


### PR DESCRIPTION
This pull request introduces support for generating partial configuration objects without top-level wrappers, making it easier to merge generated configs into existing setups. The changes add an `includeWrapper` option for configuration building, update the schema and types, and provide comprehensive tests for this new feature. Backward compatibility is maintained for existing behavior when the option is not specified.

**Partial configuration generation:**

* Added an `includeWrapper` option to the configuration builder, allowing users to generate just the server entry (e.g., `{ "my-server": { ... } }`) instead of wrapping it in `mcpServers`, `servers`, or `extensions`. This is documented in `README.md` and implemented in `src/builder.ts`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R122-R153) [[2]](diffhunk://#diff-bbc9640c6f775beba889146ac72377fb4025fbf0232f97115d38a54d3efe87d9R48-R55) [[3]](diffhunk://#diff-bbc9640c6f775beba889146ac72377fb4025fbf0232f97115d38a54d3efe87d9L68-R72) [[4]](diffhunk://#diff-bbc9640c6f775beba889146ac72377fb4025fbf0232f97115d38a54d3efe87d9L109-R131) [[5]](diffhunk://#diff-bbc9640c6f775beba889146ac72377fb4025fbf0232f97115d38a54d3efe87d9L120-R172) [[6]](diffhunk://#diff-bbc9640c6f775beba889146ac72377fb4025fbf0232f97115d38a54d3efe87d9R193-R198) [[7]](diffhunk://#diff-bbc9640c6f775beba889146ac72377fb4025fbf0232f97115d38a54d3efe87d9L170-R215) [[8]](diffhunk://#diff-bbc9640c6f775beba889146ac72377fb4025fbf0232f97115d38a54d3efe87d9R225-R242)
* Updated the configuration schema (`src/schemas.ts`) and types (`src/types.ts`) to support the new `includeWrapper` option. [[1]](diffhunk://#diff-8f5fdeb1cfe9f99fbc1c0a2c351f90ef3531ecdeefa8d0f9a4f0f4127c67f2aaL57-R80) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR15) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR38) [[4]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR66)

**Testing and documentation:**

* Added extensive tests in `test/builder.test.ts` to verify partial configuration generation for all supported clients and modes, edge cases, and backward compatibility.
* Updated `README.md` with usage examples and explanation for partial configuration merging.

**Miscellaneous improvements:**

* Improved environment variable handling for Goose client configurations to ensure correct field assignment.
* Minor code cleanup and formatting in builder logic and tests. [[1]](diffhunk://#diff-bbc9640c6f775beba889146ac72377fb4025fbf0232f97115d38a54d3efe87d9L211-R286) [[2]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dR12) [[3]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL142)