### PR TITLE
feat: Adds new constants for clients and client display names

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,54 @@
+/**
+ * Canonical client IDs for MCP clients
+ */
+export const CLIENT = {
+  CLAUDE_CODE: 'claude-code',
+  CLAUDE_DESKTOP: 'claude-desktop',
+  CLAUDE_TEAMS_ENTERPRISE: 'claude-teams-enterprise',
+  CURSOR: 'cursor',
+  VSCODE: 'vscode',
+  WINDSURF: 'windsurf',
+  GOOSE: 'goose',
+  CHATGPT: 'chatgpt',
+} as const;
+
+/**
+ * Display names for MCP clients
+ */
+export const CLIENT_DISPLAY_NAME = {
+  CLAUDE_CODE: 'Claude Code',
+  CLAUDE_DESKTOP: 'Claude for Desktop',
+  CLAUDE_TEAMS_ENTERPRISE: 'Claude for Teams/Enterprise',
+  CURSOR: 'Cursor',
+  VSCODE: 'VS Code',
+  WINDSURF: 'Windsurf',
+  GOOSE: 'Goose',
+  CHATGPT: 'ChatGPT',
+} as const;
+
+/**
+ * Type-safe client ID type derived from the constants
+ */
+export type ClientIdConstant = typeof CLIENT[keyof typeof CLIENT];
+
+/**
+ * Type-safe display name type derived from the constants
+ */
+export type ClientDisplayName = typeof CLIENT_DISPLAY_NAME[keyof typeof CLIENT_DISPLAY_NAME];
+
+/**
+ * Helper to get display name from client ID
+ */
+export function getDisplayName(clientId: ClientIdConstant): ClientDisplayName {
+  const mapping: Record<ClientIdConstant, ClientDisplayName> = {
+    [CLIENT.CLAUDE_CODE]: CLIENT_DISPLAY_NAME.CLAUDE_CODE,
+    [CLIENT.CLAUDE_DESKTOP]: CLIENT_DISPLAY_NAME.CLAUDE_DESKTOP,
+    [CLIENT.CLAUDE_TEAMS_ENTERPRISE]: CLIENT_DISPLAY_NAME.CLAUDE_TEAMS_ENTERPRISE,
+    [CLIENT.CURSOR]: CLIENT_DISPLAY_NAME.CURSOR,
+    [CLIENT.VSCODE]: CLIENT_DISPLAY_NAME.VSCODE,
+    [CLIENT.WINDSURF]: CLIENT_DISPLAY_NAME.WINDSURF,
+    [CLIENT.GOOSE]: CLIENT_DISPLAY_NAME.GOOSE,
+    [CLIENT.CHATGPT]: CLIENT_DISPLAY_NAME.CHATGPT,
+  };
+  return mapping[clientId];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types.js';
+export * from './constants.js';
 
 export { ConfigBuilder } from './builder.js';
 export { MCPConfigRegistry } from './registry.js';

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { MCPConfigRegistry } from '../src/registry';
+import { CLIENT, CLIENT_DISPLAY_NAME } from '../src/constants';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
@@ -22,29 +23,29 @@ describe('MCPConfigRegistry', () => {
     });
 
     it('should load Claude Code config', () => {
-      const config = registry.getConfig('claude-code');
+      const config = registry.getConfig(CLIENT.CLAUDE_CODE);
       expect(config).toBeDefined();
-      expect(config?.displayName).toBe('Claude Code');
+      expect(config?.displayName).toBe(CLIENT_DISPLAY_NAME.CLAUDE_CODE);
       expect(config?.clientSupports).toBe('http');
       expect(config?.requiresMcpRemoteForHttp).toBe(false);
     });
 
     it('should load VS Code config', () => {
-      const config = registry.getConfig('vscode');
+      const config = registry.getConfig(CLIENT.VSCODE);
       expect(config).toBeDefined();
       expect(config?.displayName).toBe('Visual Studio Code');
       expect(config?.configStructure.serverKey).toBe('servers');
     });
 
     it('should load Cursor config with HTTP support', () => {
-      const config = registry.getConfig('cursor');
+      const config = registry.getConfig(CLIENT.CURSOR);
       expect(config).toBeDefined();
       expect(config?.clientSupports).toBe('http');
       expect(config?.requiresMcpRemoteForHttp).toBe(false);
     });
 
     it('should load Goose config with YAML format', () => {
-      const config = registry.getConfig('goose');
+      const config = registry.getConfig(CLIENT.GOOSE);
       expect(config).toBeDefined();
       expect(config?.configFormat).toBe('yaml');
     });
@@ -77,8 +78,8 @@ describe('MCPConfigRegistry', () => {
 
     it('should get unsupported clients', () => {
       const clients = registry.getUnsupportedClients();
-      const chatgpt = clients.find((c) => c.id === 'chatgpt');
-      const claudeTeamsEnterprise = clients.find((c) => c.id === 'claude-teams-enterprise');
+      const chatgpt = clients.find((c) => c.id === CLIENT.CHATGPT);
+      const claudeTeamsEnterprise = clients.find((c) => c.id === CLIENT.CLAUDE_TEAMS_ENTERPRISE);
       expect(chatgpt).toBeDefined();
       expect(claudeTeamsEnterprise).toBeDefined();
       expect(chatgpt?.localConfigSupport).toBe('none');
@@ -88,7 +89,7 @@ describe('MCPConfigRegistry', () => {
     it('should get clients with one-click support', () => {
       const clients = registry.getClientsWithOneClick();
       expect(clients.length).toBeGreaterThan(0);
-      const cursor = clients.find((c) => c.id === 'cursor');
+      const cursor = clients.find((c) => c.id === CLIENT.CURSOR);
       expect(cursor).toBeDefined();
       expect(cursor?.oneClick?.protocol).toBe('cursor://');
     });
@@ -102,7 +103,7 @@ describe('MCPConfigRegistry', () => {
       expect(linuxClients.length).toBeGreaterThan(0);
       expect(win32Clients.length).toBeGreaterThan(0);
 
-      const claudeDesktop = registry.getConfig('claude-desktop');
+      const claudeDesktop = registry.getConfig(CLIENT.CLAUDE_DESKTOP);
       expect(darwinClients).toContainEqual(claudeDesktop);
       expect(linuxClients).not.toContainEqual(claudeDesktop);
     });


### PR DESCRIPTION
This pull request introduces type-safe constants for MCP client IDs and display names, and refactors the codebase and tests to use these new constants instead of raw string literals. This change improves maintainability, reduces the risk of typos, and ensures consistency throughout the codebase.

### Type Safety and Constants

* Added canonical client ID and display name constants (`CLIENT`, `CLIENT_DISPLAY_NAME`) to `src/constants.ts`, along with type definitions and a helper function for mapping client IDs to display names.
* Exported the new constants from the package entry point (`src/index.ts`) for use across the codebase.

### Refactoring Test Code

* Refactored all usages of raw client ID strings in `test/builder.test.ts` to use the new `CLIENT` constants, ensuring type safety and consistency in test cases. [[1]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL22-R24) [[2]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL44-R46) [[3]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL56-R58) [[4]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL76-R78) [[5]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL96-R98) [[6]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL117-R119) [[7]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL141-R143) [[8]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL177-R179) [[9]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL204-R206) [[10]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL233-R235) [[11]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL243-R287) [[12]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL318-R320) [[13]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL343-R345) [[14]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL368-R370) [[15]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL392-R394) [[16]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL430-R432) [[17]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL439-R441) [[18]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL460-R462) [[19]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL479-R484) [[20]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL497-R499) [[21]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL509-R514) [[22]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL543-R545) [[23]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL557-R559) [[24]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL571-R573) [[25]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL586-R588) [[26]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL600-R602) [[27]](diffhunk://#diff-7c0353b54bc2e402487411e68daf05a0c9030c9bab0826bedf1909b2f5dc3f3dL615-R617)

### Improved Imports

* Updated imports in `test/builder.test.ts` to include the new constants for use in test logic.