### PR TITLE
feat: Adds oneclick support for vscode (as per their docs)

### DIFF
--- a/CLIENTS.md
+++ b/CLIENTS.md
@@ -464,7 +464,7 @@ extensions:
 
 - **Compatibility**: Full local configuration support
 - **Connection Type**: Native HTTP support
-- **Documentation**: [Visual Studio Code Docs](https://code.visualstudio.com/docs)
+- **Documentation**: [Visual Studio Code Docs](https://code.visualstudio.com/docs/copilot/customization/mcp-servers)
 - **Supported Platforms**: macOS, Linux, Windows
 - **Configuration Paths**:
   - **macOS**: `$HOME/Library/Application Support/Code/User/mcp.json`
@@ -481,7 +481,7 @@ extensions:
   "displayName": "Visual Studio Code",
   "description": "VS Code with native HTTP support",
   "localConfigSupport": "full",
-  "documentationUrl": "https://code.visualstudio.com/docs",
+  "documentationUrl": "https://code.visualstudio.com/docs/copilot/customization/mcp-servers",
   "clientSupports": "http",
   "requiresMcpRemoteForHttp": false,
   "supportedPlatforms": ["darwin", "linux", "win32"],
@@ -491,11 +491,17 @@ extensions:
     "linux": "$HOME/.config/Code/User/mcp.json",
     "win32": "%APPDATA%\\Code\\User\\mcp.json"
   },
+  "oneClick": {
+    "protocol": "vscode://",
+    "urlTemplate": "vscode://mcp/install?{{config}}",
+    "configFormat": "url-encoded-json"
+  },
   "configStructure": {
     "serverKey": "servers",
     "httpConfig": {
       "typeField": "type",
-      "urlField": "url"
+      "urlField": "url",
+      "headersField": "headers"
     },
     "stdioConfig": {
       "typeField": "type",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ await builder.writeConfiguration({
   serverName: 'my-server',
 });
 
-// Generate one-click install URL for supported clients (currently only Cursor)
+// Generate one-click install URL for supported clients (Cursor, VS Code)
 const oneClickUrl = builder.buildOneClickUrl({
   mode: 'remote',
   serverUrl: 'https://your-server.com/mcp/default',
@@ -73,13 +73,12 @@ For detailed configuration examples and requirements for each client, see **[CLI
 
 ### One-Click Installation Support
 
-Currently, only Cursor has documented one-click installation support:
+The following clients support one-click installation:
 
-| Client     | Protocol    | Format                                                               |
-| ---------- | ----------- | -------------------------------------------------------------------- |
-| **Cursor** | `cursor://` | `cursor://anysphere.cursor-deeplink/mcp/install?name=...&config=...` |
-
-Note: VSCode may support one-click installation in the future, but the format has not been documented yet.
+| Client       | Protocol    | Format                                                               |
+| ------------ | ----------- | -------------------------------------------------------------------- |
+| **Cursor**   | `cursor://` | `cursor://anysphere.cursor-deeplink/mcp/install?name=...&config=...` |
+| **VS Code**  | `vscode://` | `vscode://mcp/install?{url-encoded-json-config}`                     |
 
 ## Core Usage
 

--- a/configs/vscode.json
+++ b/configs/vscode.json
@@ -4,7 +4,7 @@
   "displayName": "Visual Studio Code",
   "description": "VS Code with native HTTP support",
   "localConfigSupport": "full",
-  "documentationUrl": "https://code.visualstudio.com/docs",
+  "documentationUrl": "https://code.visualstudio.com/docs/copilot/customization/mcp-servers",
   "clientSupports": "http",
   "requiresMcpRemoteForHttp": false,
   "supportedPlatforms": ["darwin", "linux", "win32"],
@@ -14,11 +14,17 @@
     "linux": "$HOME/.config/Code/User/mcp.json",
     "win32": "%APPDATA%\\Code\\User\\mcp.json"
   },
+  "oneClick": {
+    "protocol": "vscode://",
+    "urlTemplate": "vscode://mcp/install?{{config}}",
+    "configFormat": "url-encoded-json"
+  },
   "configStructure": {
     "serverKey": "servers",
     "httpConfig": {
       "typeField": "type",
-      "urlField": "url"
+      "urlField": "url",
+      "headersField": "headers"
     },
     "stdioConfig": {
       "typeField": "type",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -20,6 +20,7 @@ export const ServerModeSchema = z.enum(['local', 'remote']);
 export const HttpConfigStructureSchema = z.object({
   typeField: z.string().optional(),
   urlField: z.string(),
+  headersField: z.string().optional(),
 });
 
 export const StdioConfigStructureSchema = z.object({


### PR DESCRIPTION
### Code changes:
* Updated the documentation links for Visual Studio Code and introduced one-click installation support, with added configuration for headers in HTTP requests and adjustments in the structure of the configuration object for VSCode.

New features include:

- **One-click installation support** with a new protocol definition, allowing easy setup via a generated URL.
- Enhanced configuration to include headers for authentication when using HTTP connections.

Changes also reflect updates in the README and code examples to integrate these new functionalities into the documentation.
