### PR TITLE
Fix ChatGPT/Claude Enterprise "requires mcp-remote"

### DIFF
--- a/CLIENTS.md
+++ b/CLIENTS.md
@@ -6,10 +6,10 @@ This document provides a comprehensive overview of all supported MCP clients, th
 
 | Client | Compatibility | Connection Type | Requires mcp-remote? | Platforms |
 |--------|--------------|-----------------|---------------------|-----------|
-| **ChatGPT** | None | HTTP only | Yes (for HTTP) | Web only |
+| **ChatGPT** | None | HTTP only | No | Web only |
 | **Claude Code** | Full | HTTP native | No | macOS, Linux, Windows |
 | **Claude for Desktop** | Full | stdio only | Yes (for HTTP) | macOS, Windows, Linux |
-| **Claude for Teams/Enterprise** | None | HTTP only | Yes (for HTTP) | Organization-managed |
+| **Claude for Teams/Enterprise** | None | HTTP only | No | Organization-managed |
 | **Cursor** | Full | HTTP native | No | macOS, Linux, Windows |
 | **Goose** | Full | HTTP native | No | macOS, Linux, Windows |
 | **Visual Studio Code** | Full | HTTP native | No | macOS, Linux, Windows |
@@ -20,7 +20,7 @@ This document provides a comprehensive overview of all supported MCP clients, th
 ### ChatGPT
 
 - **Compatibility**: No local configuration support
-- **Connection Type**: stdio only (requires mcp-remote for HTTP servers)
+- **Connection Type**: HTTP only (managed)
 - **Documentation**: [OpenAI Platform Docs](https://platform.openai.com/docs)
 - **Notes**: ChatGPT is web-based and requires creating custom GPTs through their web UI. No local configuration file support.
 
@@ -34,6 +34,7 @@ This document provides a comprehensive overview of all supported MCP clients, th
   "displayName": "ChatGPT",
   "description": "ChatGPT web interface - requires GPT configuration through web UI",
   "localConfigSupport": "none",
+  "remoteConfigSupport": "web",
   "localConfigNotes": "ChatGPT is web-based and requires creating custom GPTs through their web UI. No local configuration file support.",
   "transports": ["http"],
   "supportedPlatforms": [],
@@ -70,6 +71,7 @@ This document provides a comprehensive overview of all supported MCP clients, th
   "displayName": "Claude Code",
   "description": "Claude Code with native HTTP support",
   "localConfigSupport": "full",
+  "remoteConfigSupport": "none",
   "documentationUrl": "https://docs.anthropic.com/en/docs/claude-code",
   "transports": ["stdio", "http"],
   "supportedPlatforms": ["darwin", "linux", "win32"],
@@ -162,6 +164,7 @@ This document provides a comprehensive overview of all supported MCP clients, th
   "displayName": "Claude for Desktop",
   "description": "Claude Desktop only supports stdio, requires mcp-remote for HTTP servers",
   "localConfigSupport": "full",
+  "remoteConfigSupport": "none",
   "localConfigNotes": "Requires mcp-remote for remote servers",
   "documentationUrl": "https://docs.anthropic.com/en/docs/claude-desktop",
   "transports": ["stdio"],
@@ -236,7 +239,7 @@ This document provides a comprehensive overview of all supported MCP clients, th
 ### Claude for Teams/Enterprise
 
 - **Compatibility**: No local configuration support
-- **Connection Type**: stdio only (requires mcp-remote for HTTP servers)
+- **Connection Type**: HTTP only (managed)
 - **Documentation**: [Documentation](https://docs.anthropic.com/en/docs/claude-desktop)
 - **Notes**: MCP servers are centrally managed by admins. No local configuration support - servers must be configured at the organization level.
 
@@ -250,6 +253,7 @@ This document provides a comprehensive overview of all supported MCP clients, th
   "displayName": "Claude for Teams/Enterprise",
   "description": "Claude for Teams and Enterprise",
   "localConfigSupport": "none",
+  "remoteConfigSupport": "managed",
   "localConfigNotes": "MCP servers are centrally managed by admins. No local configuration support - servers must be configured at the organization level.",
   "transports": ["http"],
   "supportedPlatforms": [],
@@ -287,6 +291,7 @@ This document provides a comprehensive overview of all supported MCP clients, th
   "displayName": "Cursor",
   "description": "Cursor with native HTTP support",
   "localConfigSupport": "full",
+  "remoteConfigSupport": "none",
   "documentationUrl": "https://docs.cursor.com/context/model-context-protocol",
   "transports": ["stdio", "http"],
   "supportedPlatforms": ["darwin", "linux", "win32"],
@@ -383,6 +388,7 @@ This document provides a comprehensive overview of all supported MCP clients, th
   "displayName": "Goose",
   "description": "Goose with native HTTP support",
   "localConfigSupport": "full",
+  "remoteConfigSupport": "none",
   "documentationUrl": "https://github.com/block/goose",
   "transports": ["stdio", "http"],
   "supportedPlatforms": ["darwin", "linux", "win32"],
@@ -479,6 +485,7 @@ extensions:
   "displayName": "Visual Studio Code",
   "description": "VS Code with native HTTP support",
   "localConfigSupport": "full",
+  "remoteConfigSupport": "none",
   "documentationUrl": "https://code.visualstudio.com/docs/copilot/customization/mcp-servers",
   "transports": ["stdio", "http"],
   "supportedPlatforms": ["darwin", "linux", "win32"],
@@ -575,6 +582,7 @@ extensions:
   "displayName": "Windsurf",
   "description": "Windsurf only supports stdio, requires mcp-remote for HTTP servers",
   "localConfigSupport": "full",
+  "remoteConfigSupport": "none",
   "localConfigNotes": "Requires mcp-remote for remote servers",
   "documentationUrl": "https://docs.codeium.com/windsurf",
   "transports": ["stdio"],

--- a/configs/chatgpt.json
+++ b/configs/chatgpt.json
@@ -4,6 +4,7 @@
   "displayName": "ChatGPT",
   "description": "ChatGPT web interface - requires GPT configuration through web UI",
   "localConfigSupport": "none",
+  "remoteConfigSupport": "web",
   "localConfigNotes": "ChatGPT is web-based and requires creating custom GPTs through their web UI. No local configuration file support.",
   "transports": ["http"],
   "supportedPlatforms": [],

--- a/configs/claude-code.json
+++ b/configs/claude-code.json
@@ -4,6 +4,7 @@
   "displayName": "Claude Code",
   "description": "Claude Code with native HTTP support",
   "localConfigSupport": "full",
+  "remoteConfigSupport": "none",
   "documentationUrl": "https://docs.anthropic.com/en/docs/claude-code",
   "transports": ["stdio", "http"],
   "supportedPlatforms": ["darwin", "linux", "win32"],

--- a/configs/claude-desktop.json
+++ b/configs/claude-desktop.json
@@ -4,6 +4,7 @@
   "displayName": "Claude for Desktop",
   "description": "Claude Desktop only supports stdio, requires mcp-remote for HTTP servers",
   "localConfigSupport": "full",
+  "remoteConfigSupport": "none",
   "localConfigNotes": "Requires mcp-remote for remote servers",
   "documentationUrl": "https://docs.anthropic.com/en/docs/claude-desktop",
   "transports": ["stdio"],

--- a/configs/claude-teams-enterprise.json
+++ b/configs/claude-teams-enterprise.json
@@ -4,6 +4,7 @@
   "displayName": "Claude for Teams/Enterprise",
   "description": "Claude for Teams and Enterprise",
   "localConfigSupport": "none",
+  "remoteConfigSupport": "managed",
   "localConfigNotes": "MCP servers are centrally managed by admins. No local configuration support - servers must be configured at the organization level.",
   "transports": ["http"],
   "supportedPlatforms": [],

--- a/configs/cursor.json
+++ b/configs/cursor.json
@@ -4,6 +4,7 @@
   "displayName": "Cursor",
   "description": "Cursor with native HTTP support",
   "localConfigSupport": "full",
+  "remoteConfigSupport": "none",
   "documentationUrl": "https://docs.cursor.com/context/model-context-protocol",
   "transports": ["stdio", "http"],
   "supportedPlatforms": ["darwin", "linux", "win32"],

--- a/configs/goose.json
+++ b/configs/goose.json
@@ -4,6 +4,7 @@
   "displayName": "Goose",
   "description": "Goose with native HTTP support",
   "localConfigSupport": "full",
+  "remoteConfigSupport": "none",
   "documentationUrl": "https://github.com/block/goose",
   "transports": ["stdio", "http"],
   "supportedPlatforms": ["darwin", "linux", "win32"],

--- a/configs/vscode.json
+++ b/configs/vscode.json
@@ -4,6 +4,7 @@
   "displayName": "Visual Studio Code",
   "description": "VS Code with native HTTP support",
   "localConfigSupport": "full",
+  "remoteConfigSupport": "none",
   "documentationUrl": "https://code.visualstudio.com/docs/copilot/customization/mcp-servers",
   "transports": ["stdio", "http"],
   "supportedPlatforms": ["darwin", "linux", "win32"],

--- a/configs/windsurf.json
+++ b/configs/windsurf.json
@@ -4,6 +4,7 @@
   "displayName": "Windsurf",
   "description": "Windsurf only supports stdio, requires mcp-remote for HTTP servers",
   "localConfigSupport": "full",
+  "remoteConfigSupport": "none",
   "localConfigNotes": "Requires mcp-remote for remote servers",
   "documentationUrl": "https://docs.codeium.com/windsurf",
   "transports": ["stdio"],

--- a/scripts/generate-clients-md.ts
+++ b/scripts/generate-clients-md.ts
@@ -70,26 +70,24 @@ function generateQuickReference(): string {
       connectionType = 'stdio only';
     } else if (client.transports?.includes('http') && !client.transports?.includes('stdio')) {
       connectionType = 'HTTP only';
-    } else if (client.localConfigSupport === 'none') {
-      connectionType = 'stdio only';
     }
 
     // Determine if mcp-remote is needed
     const requiresRemote =
-      !client.transports?.includes('http') && client.localConfigSupport === 'full'
-        ? 'Yes (for HTTP)'
-        : client.localConfigSupport === 'none'
-          ? client.id === 'chatgpt'
-            ? 'Yes (for HTTP)'
-            : 'Yes (for HTTP)'
-          : 'No';
+      client.localConfigSupport === 'full'
+        ? !client.transports?.includes('http')
+          ? 'Yes (for HTTP)'
+          : 'No'
+        : 'No';
 
     const platforms =
       client.supportedPlatforms.length > 0
         ? formatPlatforms(client.supportedPlatforms)
-        : client.id === 'chatgpt'
+        : client.remoteConfigSupport === 'web'
           ? 'Web only'
-          : 'Organization-managed';
+          : client.remoteConfigSupport === 'managed'
+            ? 'Organization-managed'
+            : 'Unknown';
 
     return `| **${client.displayName}** | ${compatibility} | ${connectionType} | ${requiresRemote} | ${platforms} |`;
   });
@@ -122,10 +120,12 @@ function generateClientSection(client: any): string {
       `- **Connection Type**: stdio only${needsRemote ? ' (requires mcp-remote for HTTP servers)' : ''}`
     );
   } else if (client.localConfigSupport === 'none') {
-    if (client.id === 'chatgpt') {
-      info.push('- **Connection Type**: stdio only (requires mcp-remote for HTTP servers)');
-    } else {
-      info.push('- **Connection Type**: stdio only (requires mcp-remote for HTTP servers)');
+    if (client.transports?.includes('http') && !client.transports?.includes('stdio')) {
+      info.push('- **Connection Type**: HTTP only (managed)');
+    } else if (client.transports?.includes('stdio') && !client.transports?.includes('http')) {
+      info.push('- **Connection Type**: stdio only (managed)');
+    } else if (client.transports?.includes('http') && client.transports?.includes('stdio')) {
+      info.push('- **Connection Type**: HTTP and stdio (managed)');
     }
   }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -15,6 +15,9 @@ export const ServerTypeSchema = z.enum(['http', 'stdio']);
 
 export const LocalConfigSupportSchema = z.enum(['full', 'none']);
 
+// Indicates whether remote configuration is user/organization managed, web-only, or unsupported
+export const RemoteConfigSupportSchema = z.enum(['none', 'managed', 'web']);
+
 export const TransportSchema = z.enum(['stdio', 'http']);
 export const SupportedTransportsSchema = z.array(TransportSchema).min(1);
 export const HttpConfigStructureSchema = z.object({
@@ -48,6 +51,8 @@ export const MCPClientConfigSchema = z.object({
   displayName: z.string(),
   description: z.string(),
   localConfigSupport: LocalConfigSupportSchema,
+  // Whether remote configuration is handled externally (e.g., web/organization managed)
+  remoteConfigSupport: RemoteConfigSupportSchema,
   localConfigNotes: z.string().optional(),
   documentationUrl: z.string().url().optional(),
   transports: SupportedTransportsSchema,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import {
   SupportedTransportsSchema,
   ServerTypeSchema,
   LocalConfigSupportSchema,
+  RemoteConfigSupportSchema,
   TransportSchema,
   HttpConfigStructureSchema,
   StdioConfigStructureSchema,
@@ -28,6 +29,7 @@ export type ClientId = z.infer<typeof ClientIdSchema>;
 export type SupportedTransports = z.infer<typeof SupportedTransportsSchema>;
 export type ServerType = z.infer<typeof ServerTypeSchema>;
 export type LocalConfigSupport = z.infer<typeof LocalConfigSupportSchema>;
+export type RemoteConfigSupport = z.infer<typeof RemoteConfigSupportSchema>;
 export type Transport = z.infer<typeof TransportSchema>;
 export type HttpConfigStructure = z.infer<typeof HttpConfigStructureSchema>;
 export type StdioConfigStructure = z.infer<typeof StdioConfigStructureSchema>;
@@ -56,6 +58,7 @@ export {
   SupportedTransportsSchema,
   ServerTypeSchema,
   LocalConfigSupportSchema,
+  RemoteConfigSupportSchema,
   TransportSchema,
   MCPClientConfigSchema,
   PlatformPathsSchema,

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -14,6 +14,7 @@ describe('Zod Validation', () => {
         displayName: 'Claude Code',
         description: 'Test client',
         localConfigSupport: 'full',
+        remoteConfigSupport: 'none',
         transports: ['http'],
 
         supportedPlatforms: ['darwin'],
@@ -40,6 +41,7 @@ describe('Zod Validation', () => {
         displayName: 'Invalid',
         description: 'Test',
         localConfigSupport: 'full',
+        remoteConfigSupport: 'none',
         transports: ['http'],
 
         supportedPlatforms: ['darwin'],
@@ -65,6 +67,7 @@ describe('Zod Validation', () => {
         displayName: 'Claude Code',
         description: 'Test',
         localConfigSupport: 'partial', // Invalid
+        remoteConfigSupport: 'none',
         transports: ['http'],
 
         supportedPlatforms: ['darwin'],
@@ -91,6 +94,7 @@ describe('Zod Validation', () => {
         displayName: 'Claude Code',
         description: 'Test',
         localConfigSupport: 'full',
+        remoteConfigSupport: 'none',
         documentationUrl: 'https://docs.example.com',
         transports: ['http'],
 
@@ -114,6 +118,7 @@ describe('Zod Validation', () => {
         displayName: 'Claude Code',
         description: 'Test',
         localConfigSupport: 'full',
+        remoteConfigSupport: 'none',
         documentationUrl: 'not-a-url', // Invalid URL
         transports: ['http'],
 


### PR DESCRIPTION
- Add remoteConfigSupport ('none'|'managed'|'web') to schema and types
- Use this to determine whether something requires mcp
- regenerate the docs

We now say that ChatGPT and Claude Teams/Enterprise don't require mcp-remote.
